### PR TITLE
feat: add `blockNumber` method to `Eth` namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ The `isMining()` method determines if the client is mining new blocks.
 $web3->eth()->isMining(); //true 
 ```
 
+#### `blockNumber`
+
+The `blockNumber()` method returns the number (quantity) of the most recent block seen by this client.
+
+```php
+$web3->eth()->blockNumber(); // '3220' 
+```
 
 ### `Net` Namespace
 

--- a/src/Namespaces/Eth.php
+++ b/src/Namespaces/Eth.php
@@ -96,4 +96,18 @@ final class Eth
 
         return $result;
     }
+
+    /**
+     * Returns the number (quantity) of the most recent block seen by the client.
+     *
+     * @throws ErrorException|TransporterException
+     */
+    public function blockNumber(): string
+    {
+        $result = $this->transporter->request('eth_blockNumber');
+
+        assert(is_string($result));
+
+        return HexToUnsignedIntegerAsString::format($result);
+    }
 }

--- a/tests/Namespaces/Eth.php
+++ b/tests/Namespaces/Eth.php
@@ -61,3 +61,12 @@ test('is mining', function () {
     expect($this->eth->isMining())
         ->toBe(false);
 });
+
+test('block number', function (){
+    $this->transporter->shouldReceive('request')->with(
+        'eth_blockNumber'
+    )->once()->andReturn('0xc94');
+
+    expect($this->eth->blockNumber())
+        ->toBe('3220');
+});


### PR DESCRIPTION
## Description
- Adds `blockNumber()` method to `Eth` namespace

## Notes
- My understanding of this method is that it returns **quantity** of recent block numbers seen by the client. From this perspective, method name is a bit confusing. What is your suggestion about changing to `getblockNumbers()`?