### PR TITLE
improvement: improve web3_sha3 is string hex

### DIFF
--- a/src/Formatters/StringToHex.php
+++ b/src/Formatters/StringToHex.php
@@ -18,7 +18,7 @@ final class StringToHex implements Formatter
      */
     public static function format(string $value): string
     {
-        if (str_starts_with($value, '0x')) {
+        if (str_starts_with($value, '0x') && ctype_xdigit(substr($value, 2))) {
             return $value;
         }
 

--- a/tests/Namespaces/Web3.php
+++ b/tests/Namespaces/Web3.php
@@ -24,5 +24,12 @@ test('sha3', function () {
     )->once()->andReturn('0x5b2c76da96136d193336fad3fbc049867b8ca157da22f69ae0e4923648250acc');
 
     expect($this->web3->sha3('hello world'))
-        ->toBe('0x5b2c76da96136d193336fad3fbc049867b8ca157da22f69ae0e4923648250acc');
+    ->toBe('0x5b2c76da96136d193336fad3fbc049867b8ca157da22f69ae0e4923648250acc');
+
+    $this->transporter->shouldReceive('request')->with(
+        'web3_sha3', ['0x30782068656c6c6f20776f726c64']
+    )->once()->andReturn('0x9b886e3c06058fc79e473463c5a3a43d9bead0ff9c8ecf5858840094a7ace88e');
+
+    expect($this->web3->sha3('0x hello world'))
+            ->toBe('0x9b886e3c06058fc79e473463c5a3a43d9bead0ff9c8ecf5858840094a7ace88e');
 });


### PR DESCRIPTION
It is not enough to just check the first two characters to make sure a string is Hex.
Therefore the characters of the rest of the string (`substr($value, 2)` we know that the first two characters are '0x' at this point) must represent hexadecimal digits ` ctype_xdigit(substr($value, 2))`.

https://www.php.net/manual/en/function.ctype-xdigit.php
