### PR TITLE
fixed: Invalid content type #22

### DIFF
--- a/src/Transporters/Http.php
+++ b/src/Transporters/Http.php
@@ -35,7 +35,12 @@ final class Http implements Transporter
             'params'  => $params,
         ]);
 
-        $request = new Request('POST', $this->url, [], $body);
+        $headers = [
+            'Content-Type'   => 'application/json',
+            'Content-Length' => strlen($body),
+        ];
+
+        $request = new Request('POST', $this->url, $headers, $body);
 
         try {
             $contents = $this->client->sendRequest($request)->getBody()->getContents();


### PR DESCRIPTION
<img width="930" alt="1" src="https://user-images.githubusercontent.com/28760483/148537599-728e421f-bdb2-4448-aa61-e060ebca030d.png">

Some clients always respond with invalid request headers, such as me and #22 

I have fixed this problem and it has worked for me.

My client version is `Geth/v1.10.14-stable-11a3a350/linux-amd64/go1.17.5`